### PR TITLE
Fixed the table above Q22 to say "Ch2" instead of "Ch1" twice

### DIFF
--- a/Embedded-Systems/lab/lab06/inlab06.html
+++ b/Embedded-Systems/lab/lab06/inlab06.html
@@ -580,7 +580,7 @@ do this configure your oscilloscope as follows:
 <tr><td>Baud Rate		<td>1200
 <tr><td>Ch1 probe		<td>RC0
 <tr><td>Ch1 ground clip		<td>Dev board ground loop
-<tr><td>Ch1 probe		<td>RC1
+<tr><td>Ch2 probe		<td>RC1
 <tr><td>Horizontal (scale) 	<td>1ms
 <tr><td>Ch1 (scale) 		<td>1V
 <tr><td>Ch2 (scale) 		<td>1V


### PR DESCRIPTION
What the title says. Students can infer what the table means, but I'd rather they didn't have to