### PR TITLE
Fixed a dead link in the inLab14 document. It now correctly points to the Honcell battery datasheet

### DIFF
--- a/Embedded-Systems/lab/lab14/inlab14.html
+++ b/Embedded-Systems/lab/lab14/inlab14.html
@@ -259,7 +259,7 @@ cautious.
 The batteries that you are using for the daughter board are rated at 3.7V and 
 150mAh.  Since these are no-name batteries, let's look at the technical 
 documents for the 
-<a href="http://www.honcell.com/products/info/id/140.html">Honcell HCP621919</a>
+<a href="https://www.honcell.com/Public/Uploads/uploadfile/files/20240709/DATASHEETHCP6219193.7V150mAhCELL2024-596.pdf">Honcell HCP621919</a>
 battery which has a lot of common characteristics to the batteries that
 you will use.
 <br><br>


### PR DESCRIPTION
title