### PR TITLE
Clarified some lab11 instructions

### DIFF
--- a/Embedded-Systems/lab/lab11/lab11.html
+++ b/Embedded-Systems/lab/lab11/lab11.html
@@ -205,7 +205,8 @@ output.
 <li><b>W</b><br>
 Generate a sweeped frequency sine with a frequency that starts at
 startPhaseIncrement and ends and endPhaseIncrement over a time 
-period given by the sweep period.
+period given by the sweep period. The <b>entire</b> sweep should 
+take the amount of time specified in the '<b>d</b>' function. Repeat the sweep until the user presses a key to stop it.
 <br><br>
 
 <li><b>t</b><br>


### PR DESCRIPTION
Clarified that the sweep duration is the duration of the *entire* sweep, not the time to hold at each increment. This was already pretty clear in the instructions, but I had a group fail to do this. Also specified that the sweep should be repeated until the user presses a key to stop it (as seen in the solution code)